### PR TITLE
Reference implementation scaffold: API + worker + local dev stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and fill
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 node_modules
 .env
 .env.*
+!.env.example
 .DS_Store
 *.log
 coverage
+__pycache__/
+*.pyc
+services/api/dist/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: proaktive
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  localstack:
+    image: localstack/localstack:3
+    environment:
+      - SERVICES=s3,sqs
+      - DEBUG=0
+    ports:
+      - "4566:4566"
+    volumes:
+      - localstack:/var/lib/localstack
+
+  api:
+    build:
+      context: ./services/api
+    environment:
+      - PORT=3000
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/proaktive
+      - AWS_REGION=us-east-1
+      - AWS_ENDPOINT=http://localstack:4566
+      - S3_BUCKET=proaktive-dev-uploads
+      - SQS_QUEUE_URL=http://localstack:4566/000000000000/doc-ingest
+    depends_on:
+      - postgres
+      - localstack
+    ports:
+      - "3000:3000"
+
+  worker:
+    build:
+      context: ./services/worker
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/proaktive
+      - AWS_REGION=us-east-1
+      - AWS_ENDPOINT=http://localstack:4566
+      - S3_BUCKET=proaktive-dev-uploads
+      - SQS_QUEUE_URL=http://localstack:4566/000000000000/doc-ingest
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    depends_on:
+      - postgres
+      - localstack
+
+volumes:
+  pgdata:
+  localstack:

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,109 @@
+-- MVP schema (minimal)
+
+create extension if not exists citext;
+create extension if not exists pgcrypto;
+
+create table if not exists tenants (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  status text not null default 'active',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists users (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  email citext not null,
+  role text not null default 'admin',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists audit_log (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null,
+  actor_user_id uuid,
+  action text not null,
+  entity_type text not null,
+  entity_id text not null,
+  metadata_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists documents (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  filename text not null,
+  mime text,
+  sha256 text,
+  s3_key text not null,
+  status text not null default 'uploaded',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists document_chunks (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  document_id uuid not null references documents(id) on delete cascade,
+  idx int not null,
+  text text not null,
+  token_count int,
+  metadata_json jsonb not null default '{}'::jsonb
+);
+
+create table if not exists controls (
+  id uuid primary key default gen_random_uuid(),
+  framework text not null,
+  control_id text not null,
+  family text,
+  title text,
+  requirement_text text not null,
+  guidance_json jsonb not null default '{}'::jsonb,
+  version text not null default 'v1'
+);
+
+create unique index if not exists controls_uq on controls(framework, control_id, version);
+
+create table if not exists control_mappings (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  control_id text not null,
+  chunk_id uuid not null references document_chunks(id) on delete cascade,
+  score numeric,
+  confidence numeric,
+  rationale text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists implementation_statements (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  control_id text not null,
+  text text not null,
+  citations_json jsonb not null default '[]'::jsonb,
+  version int not null default 1,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists poam_items (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  control_id text not null,
+  gap_summary text,
+  remediation text,
+  priority text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists pipeline_jobs (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  document_id uuid not null references documents(id) on delete cascade,
+  step text not null,
+  input_hash text not null,
+  status text not null default 'queued',
+  error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists pipeline_jobs_uq on pipeline_jobs(tenant_id, document_id, step, input_hash);

--- a/scripts/local-init.sh
+++ b/scripts/local-init.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENDPOINT=${AWS_ENDPOINT:-http://localhost:4566}
+BUCKET=${S3_BUCKET:-proaktive-dev-uploads}
+QUEUE_NAME=${SQS_QUEUE_NAME:-doc-ingest}
+
+aws --endpoint-url="$ENDPOINT" s3 mb "s3://$BUCKET" || true
+aws --endpoint-url="$ENDPOINT" sqs create-queue --queue-name "$QUEUE_NAME" >/dev/null || true
+
+echo "Localstack initialized: bucket=$BUCKET queue=$QUEUE_NAME"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB=${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/proaktive}
+
+for f in migrations/*.sql; do
+  echo "Applying $f"
+  psql "$DB" -f "$f"
+done

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,6 @@
+# Services (reference implementation)
+
+- `api/`: NestJS API (presign upload, document metadata, kickoff jobs)
+- `worker/`: Python worker (SQS consumer + pipeline skeleton)
+
+Run locally via `docker compose up --build` from repo root.

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+EXPOSE 3000
+CMD ["npm","start"]

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,0 +1,23 @@
+# proaktive-api (reference)
+
+NestJS API reference implementation.
+
+## Endpoints
+- `GET /api/v1/health`
+- `POST /api/v1/documents/upload-url?tenantId=...` { filename, mime? }
+- `GET /api/v1/documents/:id?tenantId=...`
+- `POST /api/v1/documents/:id/process?tenantId=...`
+
+## Local run (with docker compose)
+From repo root:
+
+```bash
+docker compose up --build
+```
+
+Then create localstack resources (one-time):
+
+```bash
+aws --endpoint-url=http://localhost:4566 s3 mb s3://proaktive-dev-uploads
+aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name doc-ingest
+```

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "proaktive-api",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/main.js",
+    "dev": "ts-node-dev --respawn --transpile-only src/main.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/platform-express": "^11.0.0",
+    "aws-sdk": "^2.1692.0",
+    "pg": "^8.13.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1",
+    "uuid": "^11.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.5",
+    "@types/pg": "^8.11.11",
+    "@types/uuid": "^10.0.0",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/services/api/src/app.module.ts
+++ b/services/api/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { DocumentsController } from './documents/documents.controller';
+import { HealthController } from './health.controller';
+
+@Module({
+  controllers: [HealthController, DocumentsController],
+})
+export class AppModule {}

--- a/services/api/src/documents/documents.controller.ts
+++ b/services/api/src/documents/documents.controller.ts
@@ -1,0 +1,84 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import AWS from 'aws-sdk';
+import { Pool } from 'pg';
+
+// NOTE: reference implementation only.
+// Tenant scoping: for MVP local demo, tenantId is passed as query/header. Replace with auth+RBAC.
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+function s3Client() {
+  const region = process.env.AWS_REGION || 'us-east-1';
+  const endpoint = process.env.AWS_ENDPOINT;
+  return new AWS.S3({
+    region,
+    s3ForcePathStyle: !!endpoint,
+    endpoint,
+    accessKeyId: 'test',
+    secretAccessKey: 'test',
+  });
+}
+
+function sqsClient() {
+  const region = process.env.AWS_REGION || 'us-east-1';
+  const endpoint = process.env.AWS_ENDPOINT;
+  return new AWS.SQS({
+    region,
+    endpoint,
+    accessKeyId: 'test',
+    secretAccessKey: 'test',
+  });
+}
+
+@Controller('api/v1/documents')
+export class DocumentsController {
+  @Post('upload-url')
+  async createUploadUrl(
+    @Query('tenantId') tenantId: string,
+    @Body() body: { filename: string; mime?: string }
+  ) {
+    if (!tenantId) throw new Error('tenantId required');
+    const id = uuidv4();
+    const bucket = process.env.S3_BUCKET!;
+    const key = `${tenantId}/${id}/${body.filename}`;
+
+    const s3 = s3Client();
+    const url = await s3.getSignedUrlPromise('putObject', {
+      Bucket: bucket,
+      Key: key,
+      ContentType: body.mime || 'application/octet-stream',
+      Expires: 60 * 10,
+    });
+
+    await pool.query(
+      `insert into documents (id, tenant_id, filename, mime, s3_key, status)
+       values ($1, $2, $3, $4, $5, 'uploaded')`,
+      [id, tenantId, body.filename, body.mime || null, key]
+    );
+
+    return { documentId: id, uploadUrl: url, s3Key: key };
+  }
+
+  @Get(':id')
+  async getDocument(@Query('tenantId') tenantId: string, @Param('id') id: string) {
+    const { rows } = await pool.query(
+      `select * from documents where id=$1 and tenant_id=$2`,
+      [id, tenantId]
+    );
+    return rows[0] || null;
+  }
+
+  @Post(':id/process')
+  async kickoff(@Query('tenantId') tenantId: string, @Param('id') id: string) {
+    const queueUrl = process.env.SQS_QUEUE_URL!;
+    const sqs = sqsClient();
+
+    await sqs.sendMessage({
+      QueueUrl: queueUrl,
+      MessageBody: JSON.stringify({ tenantId, documentId: id, step: 'extract' }),
+    }).promise();
+
+    return { status: 'queued', step: 'extract' };
+  }
+}

--- a/services/api/src/health.controller.ts
+++ b/services/api/src/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('api/v1')
+export class HealthController {
+  @Get('health')
+  health() {
+    return { status: 'ok', service: 'proaktive-api' };
+  }
+}

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -1,0 +1,13 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const port = Number(process.env.PORT || '3000');
+  await app.listen(port, '0.0.0.0');
+  // eslint-disable-next-line no-console
+  console.log(`API listening on ${port}`);
+}
+
+bootstrap();

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true
+  }
+}

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["python", "-m", "app.worker"]

--- a/services/worker/README.md
+++ b/services/worker/README.md
@@ -1,0 +1,17 @@
+# proaktive-worker (reference)
+
+Python worker reference implementation.
+
+Consumes SQS messages like:
+```json
+{ "tenantId": "acme", "documentId": "...", "step": "extract" }
+```
+
+Runs placeholder pipeline steps (extract/chunk/map/draft/export).
+
+## Local run
+From repo root:
+
+```bash
+docker compose up --build
+```

--- a/services/worker/app/pipeline.py
+++ b/services/worker/app/pipeline.py
@@ -1,0 +1,44 @@
+"""Compliance pipeline placeholder steps.
+
+TODO: Implement real steps:
+- extract: pull from S3, extract text (pdf/docx), persist text artifact
+- chunk: chunk extracted text and persist document_chunks
+- map: map chunks to 800-171 controls; persist control_mappings + scoring
+- draft: generate implementation statements with citations
+- export: create export pack artifacts
+
+This file is intentionally minimal and runnable.
+"""
+
+import os
+
+
+def run_pipeline_step(*, tenant_id: str, document_id: str, step: str):
+    print({"tenant": tenant_id, "document": document_id, "step": step})
+
+    if step == "extract":
+        # TODO
+        print("TODO extract")
+        next_step = "chunk"
+    elif step == "chunk":
+        # TODO
+        print("TODO chunk")
+        next_step = "map"
+    elif step == "map":
+        # TODO
+        print("TODO map")
+        next_step = "draft"
+    elif step == "draft":
+        # TODO
+        print("TODO draft")
+        next_step = "export"
+    elif step == "export":
+        # TODO
+        print("TODO export")
+        next_step = None
+    else:
+        raise ValueError(f"Unknown step: {step}")
+
+    # TODO: enqueue next_step back to SQS
+    if next_step:
+        print(f"TODO enqueue next step: {next_step}")

--- a/services/worker/app/worker.py
+++ b/services/worker/app/worker.py
@@ -1,0 +1,51 @@
+import json
+import os
+import time
+import boto3
+
+from .pipeline import run_pipeline_step
+
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+AWS_ENDPOINT = os.getenv("AWS_ENDPOINT")
+QUEUE_URL = os.getenv("SQS_QUEUE_URL")
+
+
+def sqs_client():
+    kwargs = {"region_name": AWS_REGION}
+    if AWS_ENDPOINT:
+        kwargs["endpoint_url"] = AWS_ENDPOINT
+        kwargs["aws_access_key_id"] = "test"
+        kwargs["aws_secret_access_key"] = "test"
+    return boto3.client("sqs", **kwargs)
+
+
+def main():
+    if not QUEUE_URL:
+        raise RuntimeError("SQS_QUEUE_URL is required")
+
+    sqs = sqs_client()
+    while True:
+        resp = sqs.receive_message(
+            QueueUrl=QUEUE_URL,
+            MaxNumberOfMessages=1,
+            WaitTimeSeconds=20,
+        )
+        msgs = resp.get("Messages", [])
+        if not msgs:
+            continue
+
+        msg = msgs[0]
+        body = json.loads(msg["Body"])
+        tenant_id = body["tenantId"]
+        document_id = body["documentId"]
+        step = body.get("step", "extract")
+
+        # TODO: add idempotency check using pipeline_jobs
+        run_pipeline_step(tenant_id=tenant_id, document_id=document_id, step=step)
+
+        sqs.delete_message(QueueUrl=QUEUE_URL, ReceiptHandle=msg["ReceiptHandle"])
+        time.sleep(0.2)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/worker/requirements.txt
+++ b/services/worker/requirements.txt
@@ -1,0 +1,5 @@
+boto3==1.35.91
+psycopg[binary]==3.2.3
+python-dotenv==1.0.1
+requests==2.32.3
+openai==1.66.3


### PR DESCRIPTION
Adds a minimal, runnable reference scaffold for the CMMC L2 compliance engine MVP.

Includes:
- services/api (NestJS): presigned S3 upload URL, document metadata, kickoff processing job
- services/worker (Python): SQS consumer skeleton + placeholder pipeline steps
- docker-compose: Postgres + Localstack (S3/SQS) + api + worker
- migrations/0001_init.sql for MVP schema
- scripts: local-init + migrate

Notes:
- Tenant scoping is query-based in this reference scaffold (tenantId param). Replace with auth/RBAC in real app.
- Designed for speed; security hardening follows once we have first pilots.
